### PR TITLE
Added extension to support XSL/FO pdf generation using XML data embedded in JSON

### DIFF
--- a/extension/xsl-fop-pdf/integrationTest/fopTest.js
+++ b/extension/xsl-fop-pdf/integrationTest/fopTest.js
@@ -1,0 +1,39 @@
+﻿/*globals describe, it, beforeEach, afterEach */
+
+var assert = require("assert"),
+    fs = require('fs'),
+    path = require("path"),
+    _ = require("underscore"),
+    describeReporting = require("../../../test/helpers.js").describeReporting;
+
+
+describeReporting(path.join(__dirname, "../../../"), ["html", "fop-pdf"], function(reporter) {
+    describe('fop pdf', function () {
+        
+        it('should be rendered', function(done) {
+            this.timeout(10000);
+            
+            var request = {
+                options: { recipe: "fop", timeout: 10000 },
+                template: { content: "<?xml version='1.0' encoding='utf-8'?><fo:root xmlns:fo='http://www.w3.org/1999/XSL/Format'><fo:layout-master-set><fo:simple-page-master master-name='A4' page-width='297mm' page-height='210mm' margin-top='1cm' margin-bottom='1cm' margin-left='1cm' margin-right='1cm'><fo:region-body margin='3cm'/><fo:region-before extent='2cm'/><fo:region-after extent='2cm'/><fo:region-start extent='2cm'/><fo:region-end extent='2cm'/></fo:simple-page-master></fo:layout-master-set><fo:page-sequence master-reference='A4' format='A'><fo:flow flow-name='xsl-region-body'><fo:block><fo:inline font-weight='bold'>Hello world!</fo:inline></fo:block></fo:flow></fo:page-sequence></fo:root>" }
+            };
+            
+            _.findWhere(reporter.extensionsManager.recipes, { name: "fop-pdf" }).execute(request, { headers : {}}).then(function () {
+                done();
+            });
+        });
+        
+        it('should fail with invalid fo', function(done) {
+            this.timeout(10000);
+            var request = {
+                options: { recipe: "fop", timeout: 10000 },
+                template: { content: "hngngh<?xml version='1.0' encoding='utf-8'?><fo:FAIL xmlns:fo='http://www.w3.org/1999/XSL/Format'><fo:layout-master-set><fo:simple-page-master master-name='A4' page-width='297mm' page-height='210mm' margin-top='1cm' margin-bottom='1cm' margin-left='1cm' margin-right='1cm'><fo:region-body margin='3cm'/><fo:region-before extent='2cm'/><fo:region-after extent='2cm'/><fo:region-start extent='2cm'/><fo:region-end extent='2cm'/></fo:simple-page-master></fo:layout-master-set><fo:page-sequence master-reference='A4' format='A'><fo:flow flow-name='xsl-region-body'><fo:block><fo:inline font-weight='bold'>Hello world!</fo:inline></fo:block></fo:flow></fo:page-sequence></fo:root>" }
+            };
+            
+            _.findWhere(reporter.extensionsManager.recipes, { name: "fop-pdf" }).execute(request, { headers : {}}).then(function () {}, function() {
+                done();
+            });
+        });
+
+    });
+});

--- a/extension/xsl-fop-pdf/jsreport.config.js
+++ b/extension/xsl-fop-pdf/jsreport.config.js
@@ -1,0 +1,5 @@
+﻿module.exports = {
+  "name": "xsl-fop-pdf",
+  "main": "lib/fop.js",
+  "hasPublicPart": false
+}

--- a/extension/xsl-fop-pdf/lib/fop.js
+++ b/extension/xsl-fop-pdf/lib/fop.js
@@ -44,7 +44,7 @@ var Fop = module.exports = function (reporter) {
                 ];
 
                 var isWin = /^win/.test(process.platform);
-                var fopFile = ".\\.fop-1.1\\fop" + (isWin ? ".bat" : "");
+                var fopFile = "fop" + (isWin ? ".bat" : "");
 
                 return q.nfcall(function(cb) {
                     childProcess.execFile(fopFile, childArgs, {maxBuffer : 1024 * 1024 * 64}, function (error, stdout, stderr) {

--- a/extension/xsl-fop-pdf/lib/fop.js
+++ b/extension/xsl-fop-pdf/lib/fop.js
@@ -1,0 +1,80 @@
+﻿/*! 
+ * Copyright(c) 2014 Jan Blaha 
+ *
+ * Recipe allowing to print pdf from apache fop
+ */
+
+var childProcess = require('child_process'),
+    shortid = require("shortid"),
+    join = require("path").join,
+    _ = require("underscore"),
+    q = require("q"),
+    FS = require("q-io/fs"),
+    fs = require("fs");
+
+    ent = require("entities");
+
+var Fop = module.exports = function (reporter) {
+
+    reporter.extensionsManager.recipes.push({
+        name: "xsl-fop-pdf",
+
+        execute: function (request, response) {
+            reporter.logger.info("Rendering fop start.");
+
+            var xslFilePath = join(reporter.options.tempDirectory, shortid.generate() + ".xsl");
+            var xmlFilePath = xslFilePath.replace(".xsl", ".xml");
+            var pdfFilePath = xslFilePath.replace(".xsl", ".pdf");
+
+
+            return FS.write(xslFilePath, response.content).then(function () {
+                var inputXml = ent.decodeHTML(request.data.data);
+                return FS.write(xmlFilePath, inputXml);
+            }).then(function () {
+
+                reporter.logger.info("Rastering pdf child process start.");
+
+                var childArgs = [
+                    "-xml",
+                    xmlFilePath,
+                    "-xsl",
+                    xslFilePath,
+                    "-pdf",
+                    pdfFilePath
+                ];
+
+                var isWin = /^win/.test(process.platform);
+                var fopFile = ".\\.fop-1.1\\fop" + (isWin ? ".bat" : "");
+
+                return q.nfcall(function(cb) {
+                    childProcess.execFile(fopFile, childArgs, {maxBuffer : 1024 * 1024 * 64}, function (error, stdout, stderr) {
+                        reporter.logger.info("Rastering pdf child process end.");
+
+                        if (error !== null) {
+                            reporter.logger.error('exec error: ' + error);
+                            error.weak = true;
+                            return cb(error);
+                        }
+
+                        if (!fs.existsSync(childArgs[5])) {
+                            return cb(stderr + stdout);
+                        }
+
+
+                        response.headers["Content-Type"] = "application/pdf";
+                        response.headers["File-Extension"] = "pdf";
+                        response.headers["Content-Disposition"] = "inline; filename=\"report.pdf\"";
+
+                        return fs.readFile(childArgs[5], function (err, buf) {
+                            if (err) {
+                                return cb(err);
+                            }
+                            response.content = buf;
+                            cb();
+                        });
+                    });
+                });
+            });
+        }
+    });
+};

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "daemon": "1.1.0",
     "ejs": "2.3.1",
     "express": "4.12.3",
+	"entities": "latest",
     "feedparser": "1.0.0",
     "html-to-xlsx": "0.3.1",
     "jade": "1.9.2",


### PR DESCRIPTION
the data must be given as 
`{ data : "<html encoded data here>" }`

This acts as a recipe and the content of the report should be in XSL format. If any engine is used then the output should also be in XSL format.

The integration tests have not been updated yet.
