### PR TITLE
add option to silence logging

### DIFF
--- a/lib/extendConfig.js
+++ b/lib/extendConfig.js
@@ -1,18 +1,29 @@
 var packagejson = require('../package.json')
 var commander = require('./reportingCommander')
+var extend = require('node.extend')
 var path = require('path')
 var winston = require('winston')
 var mkdirp = require('mkdirp')
 var fs = require('fs')
 
 function addFileLogger (reporter) {
-  reporter.options.logger = reporter.options.logger || {providerName: 'winston'}
+  var defaultOpts = {
+    providerName: 'winston',
+    silent: false,
+    logDirectory: path.join(reporter.options.rootDirectory, 'logs')
+  }
+
+  reporter.options.logger = extend({}, defaultOpts, reporter.options.logger)
 
   if (reporter.options.logger && reporter.options.logger.providerName !== 'winston') {
     return
   }
 
   if (reporter.logger.transports.console) {
+    if (reporter.options.logger.silent) {
+      silentLogs(reporter.logger, true)
+    }
+
     return
   }
 
@@ -22,7 +33,7 @@ function addFileLogger (reporter) {
     level: reporter.options.mode === 'production' ? 'info' : 'debug'
   }
 
-  var logDirectory = reporter.options.logger.logDirectory || path.join(reporter.options.rootDirectory, 'logs')
+  var logDirectory = reporter.options.logger.logDirectory
 
   if (!fs.existsSync(logDirectory)) {
     mkdirp.sync(logDirectory)
@@ -43,6 +54,19 @@ function addFileLogger (reporter) {
     handleExceptions: true,
     json: false
   })
+
+  if (reporter.options.logger.silent) {
+    silentLogs(reporter.logger, true)
+  }
+}
+
+function silentLogs (logger, active) {
+  if (logger.transports) {
+    Object.keys(logger.transports).forEach(function (transportName) {
+      // this is the recommended way to modify transports in runtime, as per winston's docs
+      logger.transports[transportName].silent = active
+    })
+  }
 }
 
 module.exports = function (reporter) {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "eslint-config-standard-react": "4.2.0",
     "mocha": "3.2.0",
     "should": "11.2.0",
-    "standard": "8.6.0"
+    "standard": "8.6.0",
+    "std-mocks": "1.0.1"
   },
   "scripts": {
     "test": "mocha test --timeout 7000 && standard",

--- a/test/specs.js
+++ b/test/specs.js
@@ -1,6 +1,7 @@
 require('should')
 var jsreport = require('../')
 var path = require('path')
+var stdMocks = require('std-mocks')
 
 describe('all extensions', function () {
   var reporter
@@ -146,5 +147,66 @@ describe('in memory strategy', function () {
       resp.content.toString().should.be.eql('b')
       done()
     }).catch(done)
+  })
+})
+
+describe('logging', function () {
+  it('should log to console by default', function (done) {
+    var reporter = jsreport({
+      rootDirectory: path.join(__dirname, '../'),
+      loadConfig: false,
+      connectionString: { name: 'memory' }
+    })
+
+    stdMocks.use({ print: true })
+
+    reporter.init().then(function () {
+      return reporter.render({
+        template: { content: 'foo', engine: 'none', recipe: 'html' }
+      }).then(function (resp) {
+        var stdoutContent
+
+        stdMocks.restore()
+
+        stdoutContent = stdMocks.flush()
+
+        stdoutContent.stdout.length.should.be.above(0)
+        done()
+      })
+    }).catch(function (err) {
+      stdMocks.restore()
+
+      done(err)
+    })
+  })
+
+  it('should silent logs', function (done) {
+    var reporter = jsreport({
+      rootDirectory: path.join(__dirname, '../'),
+      loadConfig: false,
+      connectionString: { name: 'memory' },
+      logger: { silent: true }
+    })
+
+    stdMocks.use({ print: true })
+
+    reporter.init().then(function () {
+      return reporter.render({
+        template: { content: 'foo', engine: 'none', recipe: 'html' }
+      }).then(function (resp) {
+        var stdoutContent
+
+        stdMocks.restore()
+
+        stdoutContent = stdMocks.flush()
+
+        stdoutContent.stdout.length.should.be.eql(0)
+        done()
+      })
+    }).catch(function (err) {
+      stdMocks.restore()
+
+      done(err)
+    })
   })
 })


### PR DESCRIPTION
this PR adds an option to silence all transports in `reporter.logger`.

this will work from jsreport's initialization and all transports defined will be silenced.

there is an scenario where extensions potencially can add new transports to `reporter.logger`, those transports will be not affected by this option, in this case i can mock `reporter.logger.add` method to control this case and always ensure that the `silent` option is always applied and respected.

PD: i would like to also add this option to `jsreport-core`, just for consistency, maybe this option could belong in `jsreport-core` and this PR should belong there. thoughts?