### PR TITLE
Smaller docker images

### DIFF
--- a/docker/default/Dockerfile
+++ b/docker/default/Dockerfile
@@ -2,21 +2,35 @@ FROM ubuntu:yakkety
 MAINTAINER Jan Blaha
 EXPOSE 5488
 
-RUN apt-get update && apt-get install -y curl sudo && \
-    curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - && \
-    apt-get install -y nodejs libgtk2.0-dev libxtst-dev libxss1 libgconf2-dev libnss3-dev libasound2-dev
-
-RUN adduser --disabled-password --gecos "" jsreport
-RUN echo "jsreport ALL=(root) NOPASSWD: /usr/local/bin/node" >> /etc/sudoers
-RUN echo "jsreport ALL=(root) NOPASSWD: /usr/local/bin/npm" >> /etc/sudoers
+RUN adduser --disabled-password --gecos "" jsreport && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates && \
+    curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs \
+        libgtk2.0-dev \
+        libxtst-dev \
+        libxss1 \
+        libgconf2-dev \
+        libnss3-dev \
+        libasound2-dev \
+    && \
+    rm -rf /tmp/* /var/lib/apt/lists/* /var/cache/apt/* && \
+    curl -Lo phantomjs.tar.bz2 https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2 && \
+    tar jxvf phantomjs.tar.bz2 && \
+    chmod +x phantomjs-1.9.8-linux-x86_64/bin/phantomjs && \
+    mv phantomjs-1.9.8-linux-x86_64/bin/phantomjs /usr/local/bin/ && \
+    rm -rf phantomjs*
 
 VOLUME ["/jsreport"]
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-RUN sudo npm install jsreport --production
-RUN sudo node node_modules/jsreport --init
+RUN npm install jsreport --production && \
+    node node_modules/jsreport --init && \
+    npm cache clean -f && \
+    rm -rf node_modules/moment-timezone/data/unpacked && \
+    rm -rf node_modules/moment/min
 
 ADD run.sh /usr/src/app/run.sh
 COPY . /usr/src/app

--- a/docker/full/Dockerfile
+++ b/docker/full/Dockerfile
@@ -2,28 +2,47 @@ FROM ubuntu:yakkety
 MAINTAINER Jan Blaha
 EXPOSE 5488
 
-VOLUME ["/jsreport"]
-
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-
 RUN adduser --disabled-password --gecos "" jsreport && \
     apt-get update && \
     apt-get install -y --no-install-recommends curl ca-certificates && \
     curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
-    apt-get install -y --no-install-recommends nodejs npm wkhtmltopdf \
-        libgtk2.0-dev libxtst-dev libxss1 libgconf2-dev libnss3-dev libasound2-dev xvfb xfonts-75dpi xfonts-base && \
+    apt-get install -y --no-install-recommends nodejs \
+        libgtk2.0-dev \
+        libxtst-dev \
+        libxss1 \
+        libgconf2-dev \
+        libnss3-dev \
+        libasound2-dev \
+        xvfb \
+        xfonts-75dpi \
+        xfonts-base \
+        wkhtmltopdf \
+    && \
     rm -rf /tmp/* /var/lib/apt/lists/* /var/cache/apt/* && \
     curl -Lo phantomjs.tar.bz2 https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2 && \
     tar jxvf phantomjs.tar.bz2 && \
     chmod +x phantomjs-1.9.8-linux-x86_64/bin/phantomjs && \
     mv phantomjs-1.9.8-linux-x86_64/bin/phantomjs /usr/local/bin/ && \
-    rm -rf phantomjs* && \
-    npm install --production jsreport && \
+    rm -rf phantomjs*
+
+VOLUME ["/jsreport"]
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+RUN npm install --production jsreport && \
     node node_modules/jsreport --init && \
-    npm install --production --save --save-exact jsreport-ejs jsreport-jade \
-        jsreport-freeze jsreport-phantom-image jsreport-mssql-store jsreport-postgres-store \
-        jsreport-mongodb-store jsreport-wkhtmltopdf electron jsreport-electron-pdf && \
+    npm install --production --save --save-exact jsreport-ejs \
+        jsreport-jade \
+        jsreport-freeze \
+        jsreport-phantom-image \
+        jsreport-mssql-store \
+        jsreport-postgres-store \
+        jsreport-mongodb-store \
+        jsreport-wkhtmltopdf \
+        electron \
+        jsreport-electron-pdf \
+    && \
     npm cache clean -f && \
     rm -rf node_modules/moment-timezone/data/unpacked && \
     rm -rf node_modules/moment/min

--- a/docker/full/Dockerfile
+++ b/docker/full/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:zesty
+FROM ubuntu:yakkety
 MAINTAINER Jan Blaha
 EXPOSE 5488
 
@@ -9,17 +9,18 @@ WORKDIR /usr/src/app
 
 RUN adduser --disabled-password --gecos "" jsreport && \
     apt-get update && \
-    apt-get install -y --no-install-recommends curl nodejs npm ca-certificates wkhtmltopdf \
+    apt-get install -y --no-install-recommends curl ca-certificates && \
+    curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs npm wkhtmltopdf \
         libgtk2.0-dev libxtst-dev libxss1 libgconf2-dev libnss3-dev libasound2-dev xvfb xfonts-75dpi xfonts-base && \
     rm -rf /tmp/* /var/lib/apt/lists/* /var/cache/apt/* && \
-    ln -s `which nodejs` /usr/local/bin/node && \
     curl -Lo phantomjs.tar.bz2 https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2 && \
     tar jxvf phantomjs.tar.bz2 && \
     chmod +x phantomjs-1.9.8-linux-x86_64/bin/phantomjs && \
     mv phantomjs-1.9.8-linux-x86_64/bin/phantomjs /usr/local/bin/ && \
     rm -rf phantomjs* && \
     npm install --production jsreport && \
-    nodejs node_modules/jsreport --init && \
+    node node_modules/jsreport --init && \
     npm install --production --save --save-exact jsreport-ejs jsreport-jade \
         jsreport-freeze jsreport-phantom-image jsreport-mssql-store jsreport-postgres-store \
         jsreport-mongodb-store jsreport-wkhtmltopdf electron jsreport-electron-pdf && \

--- a/docker/full/Dockerfile
+++ b/docker/full/Dockerfile
@@ -11,8 +11,7 @@ RUN adduser --disabled-password --gecos "" jsreport && \
     apt-get update && \
     apt-get install -y --no-install-recommends curl nodejs npm ca-certificates wkhtmltopdf \
         libgtk2.0-dev libxtst-dev libxss1 libgconf2-dev libnss3-dev libasound2-dev xvfb xfonts-75dpi xfonts-base && \
-    apt-get clean && \
-    rm -rf /tmp/* /var/lib/apt/lists/* && \
+    rm -rf /tmp/* /var/lib/apt/lists/* /var/cache/apt/* && \
     ln -s `which nodejs` /usr/local/bin/node && \
     curl -Lo phantomjs.tar.bz2 https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2 && \
     tar jxvf phantomjs.tar.bz2 && \

--- a/docker/full/Dockerfile
+++ b/docker/full/Dockerfile
@@ -1,26 +1,32 @@
-FROM ubuntu:yakkety
+FROM ubuntu:zesty
 MAINTAINER Jan Blaha
 EXPOSE 5488
-
-RUN apt-get update && apt-get install -y curl sudo && \
-    curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - && \
-    apt-get install -y nodejs libgtk2.0-dev libxtst-dev libxss1 libgconf2-dev libnss3-dev libasound2-dev xvfb xfonts-75dpi xfonts-base
-
-RUN adduser --disabled-password --gecos "" jsreport
-RUN echo "jsreport ALL=(root) NOPASSWD: /usr/local/bin/node" >> /etc/sudoers
-RUN echo "jsreport ALL=(root) NOPASSWD: /usr/local/bin/npm" >> /etc/sudoers
 
 VOLUME ["/jsreport"]
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-RUN sudo npm install jsreport --production
-RUN sudo node node_modules/jsreport --init
-
-RUN sudo npm install --production --save --save-exact jsreport-ejs jsreport-jade jsreport-freeze jsreport-phantom-image \
-    jsreport-mssql-store jsreport-postgres-store jsreport-mongodb-store jsreport-wkhtmltopdf \
-    electron jsreport-electron-pdf
+RUN adduser --disabled-password --gecos "" jsreport && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends curl nodejs npm ca-certificates wkhtmltopdf \
+        libgtk2.0-dev libxtst-dev libxss1 libgconf2-dev libnss3-dev libasound2-dev xvfb xfonts-75dpi xfonts-base && \
+    apt-get clean && \
+    rm -rf /tmp/* /var/lib/apt/lists/* && \
+    ln -s `which nodejs` /usr/local/bin/node && \
+    curl -Lo phantomjs.tar.bz2 https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.8-linux-x86_64.tar.bz2 && \
+    tar jxvf phantomjs.tar.bz2 && \
+    chmod +x phantomjs-1.9.8-linux-x86_64/bin/phantomjs && \
+    mv phantomjs-1.9.8-linux-x86_64/bin/phantomjs /usr/local/bin/ && \
+    rm -rf phantomjs* && \
+    npm install --production jsreport && \
+    nodejs node_modules/jsreport --init && \
+    npm install --production --save --save-exact jsreport-ejs jsreport-jade \
+        jsreport-freeze jsreport-phantom-image jsreport-mssql-store jsreport-postgres-store \
+        jsreport-mongodb-store jsreport-wkhtmltopdf electron jsreport-electron-pdf && \
+    npm cache clean -f && \
+    rm -rf node_modules/moment-timezone/data/unpacked && \
+    rm -rf node_modules/moment/min
 
 ADD run.sh /usr/src/app/run.sh
 COPY . /usr/src/app


### PR DESCRIPTION
The good:
* 400 MB smaller
* Works the same (renders with phantom, electron and wkhtmltopdf)
* Downloads a single phantomjs bin rather than 3
* Kept the ubuntu base, but updated to zesty (I tried alpine* and debian:jessie**)

The bad:
* Uses node v4.8 instead of v6.x (feel free to introduce the nodesource repo again; I'm using apt-get)

Bad, but unchanged:
* Still runs as root – help appreciated!

\* phantomjs and electron broke
\*\* came out around 200MB larger than ubuntu

Note: if you're wondering why there's so much in one `RUN`, this is to build apt/npm caches and then delete them in the same layer, saving space.

Let me know if I can help with anything else. Getting a smaller image is really important for us as we're in China where internet is slow. Cheers!