### PR TITLE
Allow running the container as non-root user (only use `gosu` when running as root)

### DIFF
--- a/packages/jsreport/docker/default/run.sh
+++ b/packages/jsreport/docker/default/run.sh
@@ -24,10 +24,10 @@ if [ "$(ls -A /jsreport)" ]; then
   chown -R jsreport:jsreport /jsreport
 fi
 
-if [ $EUID > 0 ]; then
+if [ "$(id -u)" = '0' ]; then
+  # If we are root, run the app as the lower-privilege `jsreport` user
+  exec gosu jsreport node "server.js"  
+else
   # If we're not root, we can't use `gosu` (and don't need to)
   exec node "server.js"
-else
-  # If we are root, run the app as the lower-privilege `jsreport` user
-  exec gosu jsreport node "server.js"
 fi

--- a/packages/jsreport/docker/default/run.sh
+++ b/packages/jsreport/docker/default/run.sh
@@ -24,4 +24,10 @@ if [ "$(ls -A /jsreport)" ]; then
   chown -R jsreport:jsreport /jsreport
 fi
 
-exec gosu jsreport node "server.js"
+if [ $EUID > 0 ]; then
+  # If we're not root, we can't use `gosu` (and don't need to)
+  exec node "server.js"
+else
+  # If we are root, run the app as the lower-privilege `jsreport` user
+  exec gosu jsreport node "server.js"
+fi

--- a/packages/jsreport/docker/full/run.sh
+++ b/packages/jsreport/docker/full/run.sh
@@ -24,10 +24,10 @@ if [ "$(ls -A /jsreport)" ]; then
   chown -R jsreport:jsreport /jsreport
 fi
 
-if [ $EUID > 0 ]; then
-  # If we're not running as root, we can't use `gosu` (and don't need to)
-  exec node "server.js"
-else
+if [ "$(id -u)" = '0' ]; then
   # If we are root, run the app as the lower-privilege `jsreport` user
-  exec gosu jsreport node "server.js"
+  exec gosu jsreport node "server.js"  
+else
+  # If we're not root, we can't use `gosu` (and don't need to)
+  exec node "server.js"
 fi

--- a/packages/jsreport/docker/full/run.sh
+++ b/packages/jsreport/docker/full/run.sh
@@ -24,4 +24,10 @@ if [ "$(ls -A /jsreport)" ]; then
   chown -R jsreport:jsreport /jsreport
 fi
 
-exec gosu jsreport node "server.js"
+if [ $EUID > 0 ]; then
+  # If we're not running as root, we can't use `gosu` (and don't need to)
+  exec node "server.js"
+else
+  # If we are root, run the app as the lower-privilege `jsreport` user
+  exec gosu jsreport node "server.js"
+fi


### PR DESCRIPTION
### Problem
I run my containers as a non-root user for security. The changes made for #743 (using `gosu`) rely on running the initialization as root, which blocks my upgrade from v2.x to v3.x.

To reproduce, compare:
```
docker run -u jsreport:jsreport jsreport/jsreport:2.7.2
docker run -u jsreport:jsreport jsreport/jsreport:3.1.1
```
Using 3.1.1 I get the error `error: failed switching to "jsreport": operation not permitted`.

### Solution
This PR avoids calling `gosu` where it's not needed, i.e. when already running as a non-root user.

### Limitations
I'm not using mounted volumes, so I haven't looked into what happens if the non-root user can't change the permissions. If you think this needs more investigation, let me know.

I think this PR is still an improvement, since it allows running as non-root in some circumstances.

### Notes
I've tested this change against the "default" dockerfile/image. Since the "full" image uses the same script, I suggest we apply the change there as well.