### PR TITLE
Added support for specifying custom properties for PDF metadata

### DIFF
--- a/packages/jsreport-pdf-utils/test/test.js
+++ b/packages/jsreport-pdf-utils/test/test.js
@@ -1596,7 +1596,12 @@ describe('pdf utils', () => {
           keywords: 'Foo-keywords',
           creator: 'Foo-creator',
           producer: 'Foo-producer',
-          language: 'cz-CZ'
+          language: 'cz-CZ',
+          custom: {
+            serialNumber: 'Foo-123',
+            'Property With Spaces': 'foo-property-with-spaces',
+            Property_With_Underscores: 'foo-property-with-underscores'
+          }
         }
       }
     })
@@ -1609,6 +1614,8 @@ describe('pdf utils', () => {
       .and.containEql('Foo-creator')
       .and.containEql('Foo-producer')
       .and.containEql('cz-CZ')
+      .and.containEql('foo-property-with-spaces')
+      .and.containEql('foo-property-with-underscores')
   })
 
   it('pdfA should convert to valid pdfA format', async () => {
@@ -1668,7 +1675,12 @@ describe('pdf utils', () => {
           keywords: 'Foo-keywords',
           creator: 'Foo-creator',
           producer: 'Foo-producer',
-          language: 'cz-CZ'
+          language: 'cz-CZ',          
+          custom: {
+            serialNumber: 'Foo-123',
+            'Property With Spaces': 'foo-property-with-spaces',
+            Property_With_Underscores: 'foo-property-with-underscores'
+          }
         },
         scripts: [{
           content: `
@@ -1694,6 +1706,8 @@ describe('pdf utils', () => {
       .and.containEql('Foo-creator')
       .and.containEql('Foo-producer')
       .and.containEql('cz-CZ')
+      .and.containEql('foo-property-with-spaces')
+      .and.containEql('foo-property-with-underscores')
   })
 
   it('pdfSign should sign output pdf', async () => {

--- a/packages/pdfjs/lib/mixins/info.js
+++ b/packages/pdfjs/lib/mixins/info.js
@@ -42,4 +42,10 @@ function info (doc, infoOptions) {
   if (infoOptions.language) {
     doc.catalog.prop('Lang', new PDF.String(infoOptions.language))
   }
+
+  if (infoOptions.custom) {
+    Object.keys(infoOptions.custom).forEach(key => {
+      infoObject.prop(key, new PDF.String(infoOptions.custom[key]))
+    })
+  }
 }

--- a/packages/pdfjs/lib/object/name.js
+++ b/packages/pdfjs/lib/object/name.js
@@ -40,7 +40,8 @@ class PDFName {
       if (code > 0xff) {
         code = 0x5f
       }
-      return '#' + code
+
+      return '#' + code.toString(16)
     })
 
     this.name = name

--- a/packages/pdfjs/lib/object/name.js
+++ b/packages/pdfjs/lib/object/name.js
@@ -41,7 +41,7 @@ class PDFName {
         code = 0x5f
       }
 
-      return '#' + code.toString(16)
+      return '#' + intToHex(code)
     })
 
     this.name = name

--- a/packages/pdfjs/test/test.js
+++ b/packages/pdfjs/test/test.js
@@ -123,7 +123,12 @@ describe('pdfjs', () => {
       keywords: 'Foo-keywords',
       creator: 'Foo-creator',
       producer: 'Foo-producer',
-      language: 'cz-CZ'
+      language: 'cz-CZ',
+      custom: {
+        serialNumber: 'Foo-123',
+        'Property With Spaces': 'foo-property-with-spaces',
+        Property_With_Underscores: 'foo-property-with-underscores'
+      }
     })
 
     const pdfWithInfo = await document.asBuffer()
@@ -142,6 +147,9 @@ describe('pdfjs', () => {
     info.properties.get('Keywords').toString().should.be.eql('(Foo-keywords)')
     info.properties.get('Creator').toString().should.be.eql('(Foo-creator)')
     info.properties.get('Producer').toString().should.be.eql('(Foo-producer)')
+    info.properties.get('serialNumber').toString().should.be.eql('(Foo-123)')
+    info.properties.get('Property With Spaces').toString().should.be.eql('(foo-property-with-spaces)')
+    info.properties.get('Property_With_Underscores').toString().should.be.eql('(foo-property-with-underscores)')
     catalog.properties.get('Lang').toString().should.be.eql('(cz-CZ)')
   })
 
@@ -676,7 +684,12 @@ describe('pdfjs', () => {
       keywords: 'Foo-keywords',
       creator: 'Foo-creator',
       producer: 'Foo-producer',
-      language: 'cz-CZ'
+      language: 'cz-CZ',
+      custom: {
+        serialNumber: 'Foo-123',
+        'Property With Spaces': 'foo-property-with-spaces',
+        Property_With_Underscores: 'foo-property-with-underscores'
+      }
     })
 
     const pdfBuffer = await document.asBuffer()
@@ -690,6 +703,9 @@ describe('pdfjs', () => {
     info.properties.get('Keywords').toString().should.be.eql('(Foo-keywords)')
     info.properties.get('Creator').toString().should.be.eql('(Foo-creator)')
     info.properties.get('Producer').toString().should.be.eql('(Foo-producer)')
+    info.properties.get('serialNumber').toString().should.be.eql('(Foo-123)')
+    info.properties.get('Property With Spaces').toString().should.be.eql('(foo-property-with-spaces)')
+    info.properties.get('Property_With_Underscores').toString().should.be.eql('(foo-property-with-underscores)')
     catalog.properties.get('Lang').toString().should.be.eql('(cz-CZ)')
   })
 


### PR DESCRIPTION
Hi,

I couldn't find any contribution guidelines so I hope this is okay.

I've been evaluating JsReport for a project we are working on and so far it looks like the best option for our needs.

The only thing that we need that I haven't been able to do with JsReport is to add custom fields to PDF metadata. Since it is open source I decided to clone the code and see how much effort it would be. To my delight you had tests so I updated the relevant tests to fail given my new need, then dove into getting them to pass. To my further delight adding the functionality turned out to be very easy.

Modifications made:

- Updated the ```Info``` mixin of pdfjs package to look for a ```custom``` property on ```infoOptions```. If it is present, it will add all the keys from the value of that property as properties on the ```infoObject```.
- Fixed a bug in ```PDFName``` of pdf package, where when it replaces characters outside the range of 33 to 126, it was using the decimal character code instead of the hex character code as specified in the comment above the function. I found this issue as one of the scenarios I added to the test for custom fields in metadata was a field name that has spaces in it's name, with the original implementation the spaces were being converted to the number 2.

We are using JsReport via C# so if this merge request is accepted I will submit a further request with the necessary changes for custom fields to be flowed through. It seems like all that will be necessary is to add a ```Custom``` property to the ```PdfMeta``` and ensure that it will get correctly serialized as a JSON object.

I have not looked at what changes would be required to support custom fields on other clients or from config in the studio, but from the investigation I have done, it looks like these changes will not break any of those, so support can be added later when convenient.