### PR TITLE
chore(jsreport-aws-s3-storage): migrate AWS SDK for JavaScript v2 APIs to v3

### DIFF
--- a/packages/jsreport-aws-s3-storage/lib/main.js
+++ b/packages/jsreport-aws-s3-storage/lib/main.js
@@ -21,13 +21,10 @@ module.exports = function (reporter, definition) {
         accessKeyId: options.accessKeyId,
         secretAccessKey: options.secretAccessKey
       },
-
       ...options.s3Options
     })
   } else {
-    s3 = new S3({
-      ...options.s3Options
-    })
+    s3 = new S3(options.s3Options)
   }
 
   reporter.blobStorage.registerProvider({

--- a/packages/jsreport-aws-s3-storage/lib/main.js
+++ b/packages/jsreport-aws-s3-storage/lib/main.js
@@ -1,4 +1,4 @@
-const { S3 } = require('@aws-sdk/client-s3');
+const { S3 } = require('@aws-sdk/client-s3')
 
 module.exports = function (reporter, definition) {
   if (reporter.options.blobStorage.provider !== 'aws-s3-storage') {

--- a/packages/jsreport-aws-s3-storage/lib/main.js
+++ b/packages/jsreport-aws-s3-storage/lib/main.js
@@ -1,4 +1,4 @@
-const awsSDK = require('aws-sdk')
+const { S3 } = require('@aws-sdk/client-s3');
 
 module.exports = function (reporter, definition) {
   if (reporter.options.blobStorage.provider !== 'aws-s3-storage') {
@@ -16,9 +16,18 @@ module.exports = function (reporter, definition) {
 
   let s3
   if (options.accessKeyId != null && options.secretAccessKey != null) {
-    s3 = new awsSDK.S3({ accessKeyId: options.accessKeyId, secretAccessKey: options.secretAccessKey, ...options.s3Options })
+    s3 = new S3({
+      credentials: {
+        accessKeyId: options.accessKeyId,
+        secretAccessKey: options.secretAccessKey
+      },
+
+      ...options.s3Options
+    })
   } else {
-    s3 = new awsSDK.S3({ ...options.s3Options })
+    s3 = new S3({
+      ...options.s3Options
+    })
   }
 
   reporter.blobStorage.registerProvider({


### PR DESCRIPTION
From AWS SDK for JavaScript v2 [README](https://github.com/aws/aws-sdk-js):
> We are formalizing our plans to make the Maintenance Announcement (Phase 2) for AWS SDK for JavaScript v2 in 2023.

This PR migrates AWS SDK for JavaScript v2 APIs to v3 using [aws-sdk-js-codemod](https://www.npmjs.com/package/aws-sdk-js-codemod).

```console
$ npx aws-sdk-js-codemod@0.28.2 -t lib/*.js
```
