### PR TITLE
Update Node.js version to 22.2.x in GitHub workflows

### DIFF
--- a/.github/workflows/linux-binary.yaml
+++ b/.github/workflows/linux-binary.yaml
@@ -10,19 +10,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+    - name: Use Node.js 22.2.x
 
-      - name: Use Node.js 18.15.x
-        uses: actions/setup-node@v2
-        with:
-          node-version: 18.15.x
+      uses: actions/setup-node@v2
+      with:
+        node-version: 22.2.x
 
-      - run: yarn install
+    - run: yarn install
 
-      - run: yarn compile
+    - run: yarn compile
 
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: exe-output/jsreport-linux.tar.gz
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: exe-output/jsreport-linux.tar.gz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,27 +12,27 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.15.x]
+        node-version: [22.2.x]
 
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
-        with:
-          node-version: ${{ matrix.node-version }}
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
 
-      - name: Restore yarn workspaces
-        id: yarn-cache
-        uses: pat-s/always-upload-cache@v2.1.5
-        with:
-          path: |
-            node_modules
-            **/node_modules
-            ~/.cache/puppeteer
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-      - name: Install dependencies
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: rm yarn.lock && yarn install --no-progress --non-interactive
+    - name: Restore yarn workspaces
+      id: yarn-cache
+      uses: pat-s/always-upload-cache@v2.1.5
+      with:
+        path: |
+          node_modules
+          **/node_modules
+          ~/.cache/puppeteer
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    - name: Install dependencies
+      if: steps.yarn-cache.outputs.cache-hit != 'true'
+      run: rm yarn.lock && yarn install --no-progress --non-interactive
 
-      - run: yarn test
+    - run: yarn test

--- a/.github/workflows/osx-binary.yaml
+++ b/.github/workflows/osx-binary.yaml
@@ -10,21 +10,21 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+    - name: Use Node.js 22.2.x
 
-      - name: Use Node.js 18.15.x
-        uses: actions/setup-node@v2
-        with:
-          node-version: 18.15.x
+      uses: actions/setup-node@v2
+      with:
+        node-version: 22.2.x
 
-      - run: yarn install
+    - run: yarn install
 
-      - run: yarn compile
+    - run: yarn compile
 
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: |
-            exe-output/jsreport-osx-x64.tar.gz
-            exe-output/jsreport-osx-arm64.tar.gz
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: |
+          exe-output/jsreport-osx-x64.tar.gz
+          exe-output/jsreport-osx-arm64.tar.gz

--- a/.github/workflows/windows-binary.yml
+++ b/.github/workflows/windows-binary.yml
@@ -10,19 +10,19 @@ jobs:
     runs-on: windows-2022
 
     steps:
-      - uses: actions/checkout@v2
+    - uses: actions/checkout@v2
+    - name: Use Node.js 22.2.x
 
-      - name: Use Node.js 18.15.x
-        uses: actions/setup-node@v2
-        with:
-          node-version: 18.15.x
+      uses: actions/setup-node@v2
+      with:
+        node-version: 22.2.x
 
-      - run: yarn install
+    - run: yarn install
 
-      - run: yarn compile
+    - run: yarn compile
 
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: exe-output/jsreport-win.zip
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: exe-output/jsreport-win.zip

--- a/packages/jsreport/docker/default/Dockerfile
+++ b/packages/jsreport/docker/default/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.19-alpine3.19
+FROM node:22.2.0-alpine3.20
 EXPOSE 5488
 USER root
 ARG TARGETPLATFORM

--- a/packages/jsreport/docker/default/Dockerfile.local
+++ b/packages/jsreport/docker/default/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM node:18.19-alpine3.19
+FROM node:22.2.0-alpine3.20
 EXPOSE 5488
 USER root
 ARG TARGETPLATFORM


### PR DESCRIPTION
This commit updates the Node.js version to 22.2.x in the GitHub workflows for Linux, macOS, and Windows. This change ensures that the workflows use the latest stable version of Node.js, which can improve performance, security and compatibility.