### PR TITLE
remove unnecessary run layers

### DIFF
--- a/packages/jsreport/docker/default/Dockerfile
+++ b/packages/jsreport/docker/default/Dockerfile
@@ -62,8 +62,6 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
 
 RUN rm -rf /var/cache/apk/* /tmp/*
 
-RUN mkdir -p /app
-
 # we need to create the volume and give it expected owner
 # before the VOLUME step in order for the volume to be created with non-root user
 RUN mkdir /jsreport

--- a/packages/jsreport/docker/full/Dockerfile
+++ b/packages/jsreport/docker/full/Dockerfile
@@ -38,7 +38,6 @@ RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/* && \
     rm -rf /src/*.deb && \
     rm -rf /var/cache/apk/* /tmp/*
 
-RUN mkdir -p /app
 RUN mkdir -p /app/.puppeteer-cache
 
 # we need to create the volume and give it expected owner


### PR DESCRIPTION
In the default Dockerfile, we create the directory before using `WORKDIR`, which also creates the directory by default if it doesn't exist
https://docs.docker.com/reference/dockerfile/#workdir

In the full Dockerfile, the command `RUN mkdir -p /app/.puppeteer-cache` already creates the intermediate directories (in this case, `/app`, so we don't need to run the command to create that directory specifically.