### PR TITLE
html-to-xlsx: Force date and datetime to be interpreted as UTC

### DIFF
--- a/packages/html-to-xlsx/lib/tableToXlsx.js
+++ b/packages/html-to-xlsx/lib/tableToXlsx.js
@@ -221,10 +221,10 @@ function addRow (sheet, row, context) {
     } else if (cellInfo.type === 'bool' || cellInfo.type === 'boolean') {
       cell.value = cellInfo.valueText === 'true' || cellInfo.valueText === '1'
     } else if (cellInfo.type === 'date') {
-      cell.value = moment(cellInfo.valueText).toDate()
+      cell.value = moment.utc(cellInfo.valueText).toDate()
       cell.numFmt = 'yyyy-mm-dd'
     } else if (cellInfo.type === 'datetime') {
-      cell.value = moment(cellInfo.valueText).toDate()
+      cell.value = moment.utc(cellInfo.valueText).toDate()
       cell.numFmt = 'yyyy-mm-dd h:mm:ss'
     } else if (cellInfo.type === 'formula') {
       cell.value = {


### PR DESCRIPTION
The "moment" library will always interpret a date in the timezone of the operating system by default.  For Linux, that defaults to UTC, but for Windows, that timezone can vary.  This change forces the cell's text to be interpreted as UTC so that the date is not offset by the operating system's timezone when it is written to the XLSX worksheet.

For illustration: https://playground.jsreport.net/w/anon/Xf7rrI0a

The timezone of the operating system hosting playground.jsreport.net is in UTC.  If you run the same report in an on-premise jsreport installation with a non-UTC timezone, the dates and times that are written to the XLSX are _different_.

This forum topic provides additional context from another user: https://forum.jsreport.net/topic/1653/html-to-xlsx-data-cell-type-date-format-issue