### PR TITLE
Patch minimatch to 5.1.8

### DIFF
--- a/packages/jsreport-assets/package.json
+++ b/packages/jsreport-assets/package.json
@@ -36,7 +36,7 @@
     "etag": "1.8.1",
     "js-string-escape": "1.0.1",
     "mime": "2.4.4",
-    "minimatch": "5.1.0",
+    "minimatch": "5.1.8",
     "react-copy-to-clipboard": "5.0.2",
     "strip-bom-buf": "2.0.0"
   },


### PR DESCRIPTION
This fixes vulnerability [CVE-2026-27903](https://nvd.nist.gov/vuln/detail/CVE-2026-27903)

> minimatch is a minimal matching utility for converting glob expressions into JavaScript RegExp objects. Prior to version 10.2.3, 9.0.7, 8.0.6, 7.4.8, 6.2.2, 5.1.8, 4.2.5, and 3.1.3, `matchOne()` performs unbounded recursive backtracking when a glob pattern contains multiple non-adjacent `**` (GLOBSTAR) segments and the input path does not match. The time complexity is O(C(n, k)) -- binomial -- where `n` is the number of path segments and `k` is the number of globstars. With k=11 and n=30, a call to the default `minimatch()` API stalls for roughly 5 seconds. With k=13, it exceeds 15 seconds. No memoization or call budget exists to bound this behavior. Any application where an attacker can influence the glob pattern passed to `minimatch()` is vulnerable. The realistic attack surface includes build tools and task runners that accept user-supplied glob arguments (ESLint, Webpack, Rollup config), multi-tenant systems where one tenant configures glob-based rules that run in a shared process, admin or developer interfaces that accept ignore-rule or filter configuration as globs, and CI/CD pipelines that evaluate user-submitted config files containing glob patterns. An attacker who can place a crafted pattern into any of these paths can stall the Node.js event loop for tens of seconds per invocation. The pattern is 56 bytes for a 5-second stall and does not require authentication in contexts where pattern input is part of the feature. Versions 10.2.3, 9.0.7, 8.0.6, 7.4.8, 6.2.2, 5.1.8, 4.2.5, and 3.1.3 fix the issue.