### PR TITLE
core: add built-in json logger format and config-driven custom formats (#1209)

### DIFF
--- a/packages/jsreport-core/README.md
+++ b/packages/jsreport-core/README.md
@@ -162,7 +162,8 @@ require('@jsreport/jsreport-core')({
 	tempDirectory: path.join(dataDirectory, 'temp'),
 	// options for logging
 	logger: {
-		silent: false // when true, it will silence all transports defined in logger
+		silent: false, // when true, it will silence all transports defined in logger
+		format: 'text-with-timestamp' // 'text' | 'text-with-timestamp' | 'json' | name of a custom format defined under logger.formats
 	},
 	// options for templating engines and other scripts execution
 	// see the https://github.com/pofider/node-script-manager for more information
@@ -223,6 +224,84 @@ jsreport also exposes `logger` property which can be used to adapt the logging a
 const winston = require('winston')
 const jsreport = require('@jsreport/jsreport-core')()
 jsreport.logger.add(winston.transports.Console, { level: 'info' })
+```
+
+### Log output format
+
+jsreport ships with three built-in output formats. Pick one with `logger.format`:
+
+- `text` — `info: message key=value, key2=value2`
+- `text-with-timestamp` — `2024-01-01T12:00:00.000Z - info: message key=value` (default)
+- `json` — one JSON object per line, suitable for log aggregators like Datadog, Splunk, ELK
+
+```js
+require('@jsreport/jsreport-core')({
+  logger: {
+    format: 'json'
+  }
+})
+```
+
+A `json` line looks like this:
+
+```json
+{"timestamp":"2024-01-01T12:00:00.000Z","level":"info","message":"Rendering template ...","operationId":"abc123","templateName":"invoice"}
+```
+
+The JSON formatter preserves all metadata fields the text formatter would have rendered (`operationId`, `templateName`, etc.), so you keep the same structured context regardless of which format you pick.
+
+### Per-transport format
+
+Each transport can override the global format. This is useful when you want machine-readable logs to a file and human-readable logs in the console:
+
+```js
+require('@jsreport/jsreport-core')({
+  logger: {
+    console: { transport: 'console', level: 'info', format: 'text-with-timestamp' },
+    file:    { transport: 'file', level: 'info', filename: 'jsreport.log', format: 'json' }
+  }
+})
+```
+
+### Custom formats from a module
+
+Any npm module that exports a factory returning a [winston format](https://github.com/winstonjs/winston/blob/master/README.md#formats) can be registered under `logger.formats` and then referenced by name. The factory receives the `options` object you specify alongside `module`:
+
+```js
+require('@jsreport/jsreport-core')({
+  logger: {
+    formats: {
+      logstash: {
+        module: '@my/winston-logstash-format',
+        options: { app: 'reports' }
+      }
+    },
+    http: { transport: 'http', level: 'info', host: 'logs.example.com', format: 'logstash' }
+  }
+})
+```
+
+If the module's factory is not the default export, name it with `export`:
+
+```js
+formats: {
+  myformat: { module: 'some-module', export: 'createFormat', options: {} }
+}
+```
+
+A minimal custom format module looks like this:
+
+```js
+// my-format.js
+const winston = require('winston')
+const { MESSAGE } = require('triple-beam')
+
+module.exports = (options = {}) => {
+  return winston.format((info) => {
+    info[MESSAGE] = `[${options.prefix || 'APP'}] ${info.level}: ${info.message}`
+    return info
+  })
+}
 ```
 
 ## Typescript

--- a/packages/jsreport-core/lib/main/createJsonLoggerFormat.js
+++ b/packages/jsreport-core/lib/main/createJsonLoggerFormat.js
@@ -1,0 +1,32 @@
+const { MESSAGE } = require('triple-beam')
+const winston = require('winston')
+
+module.exports = (options = {}) => {
+  return winston.format((info) => {
+    const { level, message, timestamp, ...meta } = info
+    let logDate
+
+    if (timestamp == null) {
+      logDate = new Date()
+      info.timestamp = logDate.getTime()
+    } else {
+      logDate = new Date(timestamp)
+    }
+
+    const payload = {
+      timestamp: logDate.toISOString(),
+      level,
+      message
+    }
+
+    for (const k of Object.keys(meta)) {
+      // userLevel is an internal colorization hint, not user-visible data
+      if (k === 'userLevel') continue
+      payload[k] = meta[k]
+    }
+
+    info[MESSAGE] = JSON.stringify(payload)
+
+    return info
+  })
+}

--- a/packages/jsreport-core/lib/main/logger.js
+++ b/packages/jsreport-core/lib/main/logger.js
@@ -6,6 +6,7 @@ const Transport = require('winston-transport')
 const debug = require('debug')('jsreport')
 const createDefaultLoggerFormat = require('./createDefaultLoggerFormat')
 const createNormalizeMetaLoggerFormat = require('./createNormalizeMetaLoggerFormat')
+const { resolveFormat, loadCustomFormats } = require('./loggerFormats')
 const Request = require('./request')
 
 const defaultLoggerFormat = createDefaultLoggerFormat()
@@ -42,12 +43,19 @@ function configureLogger (logger, _transports) {
   const transports = _transports || {}
   const transportFormatMap = new WeakMap()
 
+  // load any user-defined custom formats from config (logger.formats: { name: { module: '...' } })
+  // safe to call repeatedly; returns an empty object if nothing is configured
+  const customFormats = loadCustomFormats(transports.formats)
+
   // we ensure we do .format cleanup on options first before checking if the logger
   // is configured or not, this ensure that options are properly cleaned up when
   // configureLogger is called more than once (like when execution cli commands from extensions)
   for (const [, transpOptions] of Object.entries(transports)) {
+    if (transpOptions == null || typeof transpOptions !== 'object' || Array.isArray(transpOptions)) {
+      continue
+    }
     if (transpOptions.format != null) {
-      transportFormatMap.set(transpOptions, transpOptions.format)
+      transportFormatMap.set(transpOptions, resolveFormat(transpOptions.format, customFormats))
       delete transpOptions.format
     }
   }
@@ -58,6 +66,16 @@ function configureLogger (logger, _transports) {
     return
   }
 
+  // apply a global logger-level format override (logger.format: 'json' | 'text' | <custom>)
+  // we keep normalizeMetaLoggerFormat in the pipeline so the format receives the same
+  // cleaned-up meta the built-in text format gets — keeps text and json output aligned
+  if (transports.format != null) {
+    logger.format = winston.format.combine(
+      normalizeMetaLoggerFormat(),
+      resolveFormat(transports.format, customFormats)
+    )
+  }
+
   const knownTransports = {
     debug: DebugTransport,
     console: winston.transports.Console,
@@ -66,10 +84,16 @@ function configureLogger (logger, _transports) {
   }
 
   const knownOptions = ['transport', 'module', 'enabled']
+  // top-level logger config keys that are not transports
+  const reservedTopLevelKeys = new Set(['format', 'formats', 'silent'])
   const transportsToAdd = []
 
   for (const [transpName, transpOptions] of Object.entries(transports)) {
     let transportModule
+
+    if (reservedTopLevelKeys.has(transpName)) {
+      continue
+    }
 
     if (!transpOptions || typeof transpOptions !== 'object' || Array.isArray(transpOptions)) {
       continue

--- a/packages/jsreport-core/lib/main/loggerFormats.js
+++ b/packages/jsreport-core/lib/main/loggerFormats.js
@@ -1,0 +1,104 @@
+const createDefaultLoggerFormat = require('./createDefaultLoggerFormat')
+const createJsonLoggerFormat = require('./createJsonLoggerFormat')
+
+const builtInFormats = {
+  text: () => createDefaultLoggerFormat(),
+  'text-with-timestamp': () => createDefaultLoggerFormat({ timestamp: true }),
+  json: () => createJsonLoggerFormat()
+}
+
+function isWinstonFormat (value) {
+  // a winston format constructor is a function returned by winston.format(fn).
+  // a winston format instance has a .transform function.
+  // we accept either.
+  if (typeof value === 'function') return true
+  if (value != null && typeof value === 'object' && typeof value.transform === 'function') return true
+  return false
+}
+
+function ensureInstance (value) {
+  // built-in / custom factories may return a winston format constructor (function)
+  // or an already-instantiated format. Normalize to an instance so consumers can
+  // always call .transform on the returned value.
+  return typeof value === 'function' ? value() : value
+}
+
+function resolveFormat (formatOption, customFormats = {}) {
+  if (formatOption == null) return null
+
+  if (isWinstonFormat(formatOption)) {
+    return ensureInstance(formatOption)
+  }
+
+  if (typeof formatOption !== 'string') {
+    throw new Error('Invalid logger format value, must be a string name or a winston format. check your "logger" config')
+  }
+
+  if (Object.prototype.hasOwnProperty.call(customFormats, formatOption)) {
+    return ensureInstance(customFormats[formatOption]())
+  }
+
+  if (Object.prototype.hasOwnProperty.call(builtInFormats, formatOption)) {
+    return ensureInstance(builtInFormats[formatOption]())
+  }
+
+  const available = [...Object.keys(builtInFormats), ...Object.keys(customFormats)].join(', ')
+  throw new Error(`Unknown logger format "${formatOption}". Available formats: ${available}. check your "logger" config`)
+}
+
+function loadCustomFormats (formatsConfig) {
+  const loaded = {}
+
+  if (formatsConfig == null) return loaded
+
+  if (typeof formatsConfig !== 'object' || Array.isArray(formatsConfig)) {
+    throw new Error('Invalid option "logger.formats", must be an object. check your "logger" config')
+  }
+
+  for (const [name, def] of Object.entries(formatsConfig)) {
+    if (def == null || typeof def !== 'object') {
+      throw new Error(`Invalid option "logger.formats.${name}", must be an object`)
+    }
+
+    if (typeof def.module !== 'string' || def.module === '') {
+      throw new Error(`Invalid option "logger.formats.${name}", option "module" must be a non-empty string`)
+    }
+
+    let mod
+    try {
+      mod = require(def.module)
+    } catch (e) {
+      if (e.code === 'MODULE_NOT_FOUND') {
+        throw new Error(`Invalid option "logger.formats.${name}", module "${def.module}" not found. are you sure that you have installed it?`)
+      }
+      throw e
+    }
+
+    let factory
+    if (typeof def.export === 'string' && def.export !== '') {
+      factory = mod[def.export]
+    } else if (typeof mod === 'function') {
+      factory = mod
+    } else if (mod != null && typeof mod.default === 'function') {
+      factory = mod.default
+    }
+
+    if (typeof factory !== 'function') {
+      throw new Error(`Invalid option "logger.formats.${name}", module "${def.module}" must export a factory function (default export or named via "export")`)
+    }
+
+    const formatOptions = def.options || {}
+
+    loaded[name] = () => {
+      const result = factory(formatOptions)
+      if (!isWinstonFormat(result)) {
+        throw new Error(`logger.formats.${name}: factory from module "${def.module}" did not return a winston format`)
+      }
+      return typeof result === 'function' ? result() : result
+    }
+  }
+
+  return loaded
+}
+
+module.exports = { resolveFormat, loadCustomFormats, builtInFormats }

--- a/packages/jsreport-core/test/fixtures/customLoggerFormat.js
+++ b/packages/jsreport-core/test/fixtures/customLoggerFormat.js
@@ -1,0 +1,11 @@
+const winston = require('winston')
+const { MESSAGE } = require('triple-beam')
+
+// test fixture: a custom logger format factory consumed by loggerFormats.loadCustomFormats
+module.exports = (options = {}) => {
+  const prefix = options.prefix || 'CUSTOM'
+  return winston.format((info) => {
+    info[MESSAGE] = `${prefix}: ${info.message}`
+    return info
+  })
+}

--- a/packages/jsreport-core/test/loggerFormatsTest.js
+++ b/packages/jsreport-core/test/loggerFormatsTest.js
@@ -1,0 +1,196 @@
+const path = require('path')
+const should = require('should')
+const winston = require('winston')
+const { MESSAGE } = require('triple-beam')
+const { resolveFormat, loadCustomFormats, builtInFormats } = require('../lib/main/loggerFormats')
+const createJsonLoggerFormat = require('../lib/main/createJsonLoggerFormat')
+
+describe('loggerFormats', () => {
+  const customFixturePath = path.join(__dirname, 'fixtures', 'customLoggerFormat.js')
+
+  describe('builtInFormats', () => {
+    it('should expose text, text-with-timestamp and json built-ins', () => {
+      builtInFormats.should.have.property('text')
+      builtInFormats.should.have.property('text-with-timestamp')
+      builtInFormats.should.have.property('json')
+    })
+  })
+
+  describe('resolveFormat', () => {
+    it('should return null for null/undefined input', () => {
+      should(resolveFormat(null)).be.Null()
+      should(resolveFormat(undefined)).be.Null()
+    })
+
+    it('should resolve "json" to a winston format with a transform method', () => {
+      const fmt = resolveFormat('json')
+      should(fmt).not.be.Null()
+      should(typeof fmt.transform).be.eql('function')
+    })
+
+    it('should resolve "text" and "text-with-timestamp" to winston formats', () => {
+      should(typeof resolveFormat('text').transform).be.eql('function')
+      should(typeof resolveFormat('text-with-timestamp').transform).be.eql('function')
+    })
+
+    it('should throw on unknown format names', () => {
+      ;(() => resolveFormat('does-not-exist')).should.throw(/Unknown logger format "does-not-exist"/)
+    })
+
+    it('should prefer a custom format over a built-in with the same name', () => {
+      const customs = {
+        json: () => winston.format((info) => {
+          info[MESSAGE] = 'custom-json-override'
+          return info
+        })()
+      }
+
+      const fmt = resolveFormat('json', customs)
+      const out = fmt.transform({ level: 'info', message: 'x' })
+      out[MESSAGE].should.eql('custom-json-override')
+    })
+
+    it('should instantiate a winston format constructor and return an instance', () => {
+      const constructor = winston.format((info) => info)
+      const fmt = resolveFormat(constructor)
+      should(typeof fmt.transform).be.eql('function')
+    })
+
+    it('should accept and return a winston format instance as-is', () => {
+      const instance = winston.format((info) => info)()
+      const fmt = resolveFormat(instance)
+      should(fmt).equal(instance)
+    })
+
+    it('should throw on non-string non-format input', () => {
+      ;(() => resolveFormat(42)).should.throw(/must be a string name or a winston format/)
+      ;(() => resolveFormat({})).should.throw(/must be a string name or a winston format/)
+    })
+  })
+
+  describe('loadCustomFormats', () => {
+    it('should return an empty object for null/undefined input', () => {
+      loadCustomFormats(null).should.eql({})
+      loadCustomFormats(undefined).should.eql({})
+    })
+
+    it('should throw if formats config is an array', () => {
+      ;(() => loadCustomFormats([])).should.throw(/must be an object/)
+    })
+
+    it('should load a fixture format module and produce a callable factory', () => {
+      const loaded = loadCustomFormats({
+        mycustom: { module: customFixturePath, options: { prefix: 'XYZ' } }
+      })
+
+      loaded.should.have.property('mycustom')
+      should(typeof loaded.mycustom).be.eql('function')
+
+      const fmt = loaded.mycustom()
+      should(typeof fmt.transform).be.eql('function')
+
+      const out = fmt.transform({ level: 'info', message: 'hi' })
+      out[MESSAGE].should.eql('XYZ: hi')
+    })
+
+    it('should default options to {} when omitted', () => {
+      const loaded = loadCustomFormats({
+        mycustom: { module: customFixturePath }
+      })
+
+      const fmt = loaded.mycustom()
+      const out = fmt.transform({ level: 'info', message: 'hi' })
+      // fixture defaults prefix to 'CUSTOM'
+      out[MESSAGE].should.eql('CUSTOM: hi')
+    })
+
+    it('should throw on missing module string', () => {
+      ;(() => loadCustomFormats({ bad: {} })).should.throw(/option "module" must be a non-empty string/)
+    })
+
+    it('should throw with a helpful message on module not found', () => {
+      ;(() => loadCustomFormats({
+        bad: { module: 'definitely-not-a-real-module-xyz' }
+      })).should.throw(/module "definitely-not-a-real-module-xyz" not found/)
+    })
+
+    it('should throw if entry is null', () => {
+      ;(() => loadCustomFormats({ bad: null })).should.throw(/must be an object/)
+    })
+  })
+
+  describe('createJsonLoggerFormat', () => {
+    it('should set info[MESSAGE] to a JSON string with level, message, timestamp', () => {
+      const fmt = createJsonLoggerFormat()()
+      const out = fmt.transform({
+        level: 'info',
+        message: 'hello',
+        timestamp: 1700000000000
+      })
+
+      const parsed = JSON.parse(out[MESSAGE])
+      parsed.should.have.property('level', 'info')
+      parsed.should.have.property('message', 'hello')
+      parsed.should.have.property('timestamp')
+      // timestamp should be ISO formatted
+      parsed.timestamp.should.match(/^\d{4}-\d{2}-\d{2}T/)
+    })
+
+    it('should preserve arbitrary metadata fields in the JSON payload', () => {
+      const fmt = createJsonLoggerFormat()()
+      const out = fmt.transform({
+        level: 'warn',
+        message: 'msg',
+        templateName: 'invoice',
+        operationId: 'op-1'
+      })
+
+      const parsed = JSON.parse(out[MESSAGE])
+      parsed.should.have.property('templateName', 'invoice')
+      parsed.should.have.property('operationId', 'op-1')
+    })
+
+    it('should not include the internal "userLevel" hint', () => {
+      const fmt = createJsonLoggerFormat()()
+      const out = fmt.transform({
+        level: 'info',
+        message: 'hello',
+        userLevel: true
+      })
+
+      const parsed = JSON.parse(out[MESSAGE])
+      parsed.should.not.have.property('userLevel')
+    })
+
+    it('should generate a timestamp if missing', () => {
+      const fmt = createJsonLoggerFormat()()
+      const info = { level: 'info', message: 'hello' }
+      const out = fmt.transform(info)
+
+      const parsed = JSON.parse(out[MESSAGE])
+      parsed.should.have.property('timestamp')
+      // info.timestamp should also be assigned (numeric)
+      should(info.timestamp).be.a.Number()
+    })
+  })
+
+  describe('integration with normalizeMeta + json format', () => {
+    it('should pipe meta through normalize then JSON via winston.combine', () => {
+      const createNormalizeMetaLoggerFormat = require('../lib/main/createNormalizeMetaLoggerFormat')
+      const combined = winston.format.combine(
+        createNormalizeMetaLoggerFormat()(),
+        createJsonLoggerFormat()()
+      )
+
+      const out = combined.transform({
+        level: 'info',
+        message: 'hi',
+        timestamp: 1700000000000
+      })
+
+      const parsed = JSON.parse(out[MESSAGE])
+      parsed.should.have.property('level', 'info')
+      parsed.should.have.property('message', 'hi')
+    })
+  })
+})

--- a/packages/jsreport-core/test/reporterTest.js
+++ b/packages/jsreport-core/test/reporterTest.js
@@ -188,6 +188,211 @@ describe('reporter', () => {
     should(logglyT).not.be.Undefined()
   })
 
+  describe('logger formats', () => {
+    const { MESSAGE } = require('triple-beam')
+    const customFormatFixturePath = path.join(__dirname, 'fixtures', 'customLoggerFormat.js')
+
+    it('should produce JSON output when global format is "json"', async () => {
+      reporter = core({ discover: false, logger: { format: 'json' } })
+      await reporter.init()
+
+      const result = reporter.logger.format.transform({
+        level: 'info',
+        message: 'hello',
+        timestamp: 1700000000000,
+        customField: 'value'
+      })
+
+      should(result).not.be.False()
+      const output = result[MESSAGE]
+      const parsed = JSON.parse(output)
+      parsed.should.have.property('level', 'info')
+      parsed.should.have.property('message', 'hello')
+      parsed.should.have.property('timestamp')
+      parsed.should.have.property('customField', 'value')
+    })
+
+    it('should produce text output when global format is "text-with-timestamp"', async () => {
+      reporter = core({ discover: false, logger: { format: 'text-with-timestamp' } })
+      await reporter.init()
+
+      const result = reporter.logger.format.transform({
+        level: 'info',
+        message: 'hello'
+      })
+
+      const output = result[MESSAGE]
+      output.should.match(/info: hello/)
+      // text-with-timestamp prefixes with an ISO timestamp
+      output.should.match(/^\d{4}-\d{2}-\d{2}T/)
+    })
+
+    it('should produce text output without timestamp when format is "text"', async () => {
+      reporter = core({ discover: false, logger: { format: 'text' } })
+      await reporter.init()
+
+      const result = reporter.logger.format.transform({
+        level: 'info',
+        message: 'hello'
+      })
+
+      const output = result[MESSAGE]
+      output.should.match(/^info: hello/)
+    })
+
+    it('should reject an unknown global format name', () => {
+      reporter = core({ discover: false, logger: { format: 'nonexistent-format' } })
+      return should(reporter.init()).be.rejectedWith(/Unknown logger format "nonexistent-format"/)
+    })
+
+    it('should accept a per-transport format as a string name', async () => {
+      reporter = core({
+        discover: false,
+        logger: {
+          console: { transport: 'console', level: 'info', format: 'json' }
+        }
+      })
+
+      await reporter.init()
+
+      const consoleT = reporter.logger.transports.find((t) => t.name === 'console')
+      should(consoleT).not.be.Undefined()
+      // when format is set on a transport, winston attaches the resolved format instance
+      should(consoleT.format).not.be.Undefined()
+      should(typeof consoleT.format.transform).be.eql('function')
+    })
+
+    it('should reject an unknown per-transport format name', () => {
+      reporter = core({
+        discover: false,
+        logger: {
+          console: { transport: 'console', level: 'info', format: 'bogus-format' }
+        }
+      })
+
+      return should(reporter.init()).be.rejectedWith(/Unknown logger format "bogus-format"/)
+    })
+
+    it('should not treat the "format" key as a transport', async () => {
+      reporter = core({
+        discover: false,
+        logger: {
+          format: 'json',
+          console: { transport: 'console', level: 'info' }
+        }
+      })
+
+      await reporter.init()
+
+      const consoleT = reporter.logger.transports.find((t) => t.name === 'console')
+      should(consoleT).not.be.Undefined()
+      // "format" must not have been added as a transport
+      should(reporter.logger.transports.find((t) => t.name === 'format')).be.Undefined()
+    })
+
+    it('should not treat the "formats" key as a transport', async () => {
+      reporter = core({
+        discover: false,
+        logger: {
+          formats: {},
+          console: { transport: 'console', level: 'info' }
+        }
+      })
+
+      await reporter.init()
+
+      const consoleT = reporter.logger.transports.find((t) => t.name === 'console')
+      should(consoleT).not.be.Undefined()
+      should(reporter.logger.transports.find((t) => t.name === 'formats')).be.Undefined()
+    })
+
+    it('should load a custom format from a module and make it usable by name', async () => {
+      reporter = core({
+        discover: false,
+        logger: {
+          formats: {
+            mycustom: { module: customFormatFixturePath, options: { prefix: 'TEST' } }
+          },
+          format: 'mycustom'
+        }
+      })
+
+      await reporter.init()
+
+      const result = reporter.logger.format.transform({
+        level: 'info',
+        message: 'hello'
+      })
+
+      const output = result[MESSAGE]
+      output.should.eql('TEST: hello')
+    })
+
+    it('should allow a custom format on a per-transport basis', async () => {
+      reporter = core({
+        discover: false,
+        logger: {
+          formats: {
+            mycustom: { module: customFormatFixturePath }
+          },
+          console: { transport: 'console', level: 'info', format: 'mycustom' }
+        }
+      })
+
+      await reporter.init()
+
+      const consoleT = reporter.logger.transports.find((t) => t.name === 'console')
+      should(consoleT).not.be.Undefined()
+      should(consoleT.format).not.be.Undefined()
+    })
+
+    it('should reject a custom format whose module cannot be found', () => {
+      reporter = core({
+        discover: false,
+        logger: {
+          formats: {
+            broken: { module: 'this-module-does-not-exist-xyz' }
+          },
+          format: 'broken'
+        }
+      })
+
+      return should(reporter.init()).be.rejectedWith(/module "this-module-does-not-exist-xyz" not found/)
+    })
+
+    it('should preserve metadata fields in JSON output', async () => {
+      reporter = core({ discover: false, logger: { format: 'json' } })
+      await reporter.init()
+
+      const result = reporter.logger.format.transform({
+        level: 'warn',
+        message: 'something happened',
+        timestamp: 1700000000000,
+        operationId: 'op-123',
+        templateName: 'invoice'
+      })
+
+      const parsed = JSON.parse(result[MESSAGE])
+      parsed.should.have.property('level', 'warn')
+      parsed.should.have.property('operationId', 'op-123')
+      parsed.should.have.property('templateName', 'invoice')
+    })
+
+    it('should not include the internal "userLevel" hint in JSON output', async () => {
+      reporter = core({ discover: false, logger: { format: 'json' } })
+      await reporter.init()
+
+      const result = reporter.logger.format.transform({
+        level: 'info',
+        message: 'hello',
+        userLevel: true
+      })
+
+      const parsed = JSON.parse(result[MESSAGE])
+      parsed.should.not.have.property('userLevel')
+    })
+  })
+
   it('should create custom error', async () => {
     reporter = core({
       discover: false


### PR DESCRIPTION
Closes #1209

## What this adds

A `logger.format` option to switch log output globally between three built-in formats, plus per-transport `format` overrides and a `logger.formats` registry that loads custom winston formats from npm modules.

Built-in formats:
- `text` — existing `info: message key=value` style
- `text-with-timestamp` — same with an ISO timestamp prefix (current default)
- `json` — one JSON object per line, suitable for log aggregators

## Examples

Flip everything to JSON:
```js
require('@jsreport/jsreport-core')({
  logger: { format: 'json' }
})